### PR TITLE
For the issue 4409

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -383,6 +383,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         probe = new JinjaJarResource("/kubernetes/manifests/httpReadinessProbe.yml");
         probe.addBinding("port", settings.getPort());
         probe.addBinding("path", settings.getHealthEndpoint());
+        probe.addBinding("scheme", settings.getScheme().toUpperCase());
       }
     } else {
       probe = new JinjaJarResource("/kubernetes/manifests/tcpSocketReadinessProbe.yml");

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/httpReadinessProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/httpReadinessProbe.yml
@@ -2,5 +2,6 @@
   "httpGet": {
     "port": {{ port }},
     "path": "{{ path }}"
+    "scheme": "{{ scheme }}"
   }
 }


### PR DESCRIPTION
…1344)

Kubernetes httpGet readiness probe

Setting kubernetes.useExecHealthCheck: false as a custom service setting
for gate configures the Kubernetes readiness check to use the built-in
httpGet functionality instead of using the external wget command. We
found that the HTTPS scheme is not specified when the endpoints use TLS
thereby resulting in failed readiness probes. This commit adds the
missing support for the HTTPS scheme.